### PR TITLE
Use the *new* rocc-software API

### DIFF
--- a/bareMetal/accumulator.S
+++ b/bareMetal/accumulator.S
@@ -14,32 +14,32 @@ start:
   // k_DO_READ after k_DO_WRITE
   li a0, 1
   lw a1, data
-  ROCC_INSTRUCTION_RAW_R_R_R(CUSTOM_X,  0, 11, 10, k_DO_WRITE)
-  ROCC_INSTRUCTION_RAW_R_R_R(CUSTOM_X, 10,  0, 10, k_DO_READ)
+  ROCC_INSTRUCTION_RAW_0_R_R(CUSTOM_X, a1, a0, k_DO_WRITE)
+  ROCC_INSTRUCTION_RAW_R_R_R(CUSTOM_X, a0, x0, a0, k_DO_READ)
   TEST_CASE(1, a0, 0xdead, )
 
   // k_DO_ACCUM should return old value
   li a0, 1
   lw a2, data + 8
   sub a2, a2, a1
-  ROCC_INSTRUCTION_RAW_R_R_R(CUSTOM_X, 10, 12, 10, k_DO_ACCUM)
+  ROCC_INSTRUCTION_RAW_R_R_R(CUSTOM_X, a0, a2, a0, k_DO_ACCUM)
   TEST_CASE(2, a0, 0xdead, )
 
   // k_DO_ACCUM should have accumulated
   li a0, 1
   lw a2, data + 8
-  ROCC_INSTRUCTION_RAW_R_R_R(CUSTOM_X, 10, 0, 10, k_DO_READ)
+  ROCC_INSTRUCTION_RAW_R_R_R(CUSTOM_X, a0, x0, a0, k_DO_READ)
   TEST_CASE(3, a0, 0xbeef, )
 
   // k_DO_LOAD should return old value
   li a0, 1
   la a1, data + 16
-  ROCC_INSTRUCTION_RAW_R_R_R(CUSTOM_X, 10, 11, 10, k_DO_LOAD)
+  ROCC_INSTRUCTION_RAW_R_R_R(CUSTOM_X, a0, a1, a0, k_DO_LOAD)
   TEST_CASE(4, a0, 0xbeef, )
 
   // k_DO_LOAD should load new value
   li a0, 1
-  ROCC_INSTRUCTION_RAW_R_R_R(CUSTOM_X, 10, 0, 10, k_DO_READ)
+  ROCC_INSTRUCTION_RAW_R_R_R(CUSTOM_X, a0, x0, a0, k_DO_READ)
   TEST_CASE(5, a0, 0x0bad, )
 
   TEST_PASSFAIL


### PR DESCRIPTION
This updates rocket-rocc-software to use a newer API that's to-be-merged for `rocc-software`. The big change is that now `rocc-software` will use `.insn` pseudo instructions as opposed to raw `.word`. This may have the benefit of actually removing duplicate `mv` instructions, but I'm not sure. 

FYI, @pranav-prakash.

### Dependencies

- prerequisites: https://github.com/IBM/rocc-software/pull/5
